### PR TITLE
Update GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,8 +17,8 @@ The following code repositories are governed by Harbor community and maintained 
 ## Community Roles
 
 * **Users:** members that engage with the Harbor community via any medium (Slack, WeChat, GitHub, mailing lists, etc.)
-* **Contributors:** regular contributions to projects (documentation, code reviews, responding to issues, participation in proposal discussions, contributing code, etc.). Two levels of maintainership are defined below.
-* **Maintainers**: see definitions and distinction below
+* **Contributors:** regular contributions to projects (documentation, code reviews, responding to issues, participation in proposal discussions, contributing code, etc.). 
+* **Maintainers**: Two levels of maintainership are defined in the Project Leadership section below.
 
 ## Project Leadership
 
@@ -29,7 +29,7 @@ There are two roles that convey project leadership: maintainers and core maintai
 
 ### Supermajority
 
-A supermajority is defined as two-thirds of members in the group (e.g., non-core maintainers or core maintainers) that require the majority.
+A supermajority is defined as two-thirds of members in the group. A supermajority of Maintainers, Core Maintainers, or the union of both is required for certain decisions as outlined below.
 
 ### Total Maintainership
 
@@ -47,15 +47,15 @@ Nomination for core maintainership requires (a) a nomination by an existing core
 
 Ideally, all project decisions are resolved by consensus. If impossible, any maintainer may call a vote. Unless otherwise specified in this document, any vote will be decided by a supermajority of the total maintainership, with a requirement of at least one core maintainer voting.
 
-Votes by maintainers (either core or non-core) belonging to the same company will count as one vote; e.g., 4 maintainers employed by company `${x}` will only have **one** combined vote.
+Votes by maintainers (either core or non-core) belonging to the same company will count as one vote; e.g., 4 maintainers employed by company `${x}` will only have **one** combined vote. If voting members from a given company do not agree, the company's vote is determined by a supermajority of voters from that company. If no supermajority is achieved, the company is considered to have abstained.
 
 ## Proposal Process
 
-One of the most important aspects in any open source community is the concept of proposals. Large changes to the codebase and / or new features should be preceded by a proposal in our community repo. This process allows for all members of the community to weigh in on the concept (including the technical details), share their comments and ideas, and even offer to help. It also ensures that members are not duplicating work or inadvertently stepping on toes by making large conflicting changes.
+One of the most important aspects in any open source community is the concept of proposals. Large changes to the codebase and / or new features should be preceded by a proposal in our community repo. This process allows for all members of the community to weigh in on the concept (including the technical details), share their comments and ideas, and offer to help. It also ensures that members are not duplicating work or inadvertently stepping on toes by making large conflicting changes.
 
 The project roadmap is defined by accepted proposals.
 
-Proposals should cover the high-level objectives, use cases, and technical recommendations on how to implement. In general, the community member interested in implementing the proposal should be either deeply engaged in the proposal process or be the author of the proposal {him,her}self.
+Proposals should cover the high-level objectives, use cases, and technical recommendations on how to implement. In general, the community member(s) interested in implementing the proposal should be either deeply engaged in the proposal process or be an author of the proposal.
 
 The proposal should be documented as a separated markdown file pushed to the `proposals` folder in the [community](https://github.com/goHarbor/community) repository via PR. The name of the file should follow the name pattern `<short meaningful words joined by '-'>_proposal.md`, e.g: `clear-old-tags-with-policies_proposal.md`.
 
@@ -66,10 +66,10 @@ See this [PR](https://github.com/goharbor/community/pull/4) as a good example of
 The proposal PR can be marked with different status labels to represent the status of the proposal:
 
 * **New**: Proposal is just created
-* **Reviewing**: Proposal is under reviewing and discussion
-* **Accepted**: Proposal is reviewed and voted to accept
-* **Rejected**: Proposal is reviewed but not enough votes got
+* **Reviewing**: Proposal is under review and discussion
+* **Accepted**: Proposal is reviewed and accepted (either by consensus or vote)
+* **Rejected**: Proposal is reviewed and rejected (either by consensus or vote)
 
 ## Updating Governance
 
-All changes in Governance require a supermajority total organizational (non-core + core maintainers) vote.
+All changes in Governance require a supermajority Total Maintainership.


### PR DESCRIPTION
I've suggested a way to handle voting when members of a company don't agree. For proposal acceptance I've also suggested that decisions could be made by consensus as opposed to a vote. If votes are always expected for proposal acceptance, the voting section should be amended as such. There are also some additional minor changes in this PR.